### PR TITLE
Prepare for DOID using new OMIMPS prefix

### DIFF
--- a/loadTerms.py
+++ b/loadTerms.py
@@ -768,6 +768,11 @@ class TermLoad:
             else:
                 xrefs = prefixPart.split(':')
                 findLDB = xrefs[0]
+                if findLDB == 'OMIMPS':
+                    # Prepare for DOID to apply proper prefixes for OMIM Phenotype series terms
+                    # See: https://github.com/DiseaseOntology/HumanDiseaseOntology/pull/968
+                    findLDB = 'OMIM:PS'
+
             results = db.sql('''select _LogicalDB_key from ACC_LogicalDB where name = '%s' ''' % (findLDB), 'auto')
             if len(results) > 0:
                 useLogicalDBkey = results[0]['_LogicalDB_key']


### PR DESCRIPTION
I've sent DOID a pull request to use a more appropriate prefix for OMIM Phenotype series identifiers rather than grouping them with other OMIM terms. This change will make MGI's code both forward and backwards compatible.

See discussion at https://github.com/DiseaseOntology/HumanDiseaseOntology/pull/968 and the related issue (linked in its description)

Related: 
- https://github.com/mgijax/fewi/pull/1
- https://github.com/mgijax/fewi/pull/2

CC @sbello